### PR TITLE
feat: add option to pass in link wrapper

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,21 @@
 import { Transition, Dialog } from "@headlessui/react";
-import { Fragment } from "react";
+import React, { Fragment } from "react";
 import { create } from "zustand";
 import "./index.css";
 
 type ContextMenuOption =
   | { name: string; onClick?: () => void; className?: string }
-  | { name: string; href: string; className?: string };
+  | {
+      name: string;
+      href: string;
+      className?: string;
+      wrapper?: React.ComponentType<{
+        href: string;
+        onClick?: () => void;
+        className?: string;
+        children?: React.ReactNode;
+      }>;
+    };
 
 interface ContextMenuState {
   show: boolean;
@@ -118,6 +128,23 @@ function renderOptions(options: ContextMenuOption[]) {
       );
     }
     if ("href" in option) {
+      if (option.wrapper) {
+        return (
+          <option.wrapper
+            key={index}
+            className={classNames(
+              "inline-block w-full cursor-pointer p-2",
+              option.className || ""
+            )}
+            href={option.href}
+            onClick={() => {
+              useContextMenu.getState().clearContextMenu();
+            }}
+          >
+            {option.name}
+          </option.wrapper>
+        );
+      }
       return (
         <a
           key={index}


### PR DESCRIPTION
Some frameworks (like Next) offer link components (for example: `next/Link`) as replacements for the native `<a>` tag.

They usually come with different benefits like persistent global state, etc.

We want to offer support for that without making those frameworks dependencies on this library.